### PR TITLE
Add Nabla ambient listening in LBF

### DIFF
--- a/interface/forms/LBF/nabla.js
+++ b/interface/forms/LBF/nabla.js
@@ -1,0 +1,43 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        var btn = document.getElementById('nabla-record-btn');
+        if(!btn){return;}
+        var recorder; var chunks=[]; var stream;
+        async function start(){
+            stream = await navigator.mediaDevices.getUserMedia({audio:true});
+            recorder = new MediaRecorder(stream);
+            recorder.ondataavailable = e => chunks.push(e.data);
+            recorder.onstop = upload;
+            recorder.start();
+            btn.textContent = 'Stop Nabla Recording';
+            btn.classList.add('btn-danger');
+        }
+        function stop(){
+            recorder.stop();
+            stream.getTracks().forEach(t=>t.stop());
+            recorder = null;
+            btn.textContent = 'Start Nabla Recording';
+            btn.classList.remove('btn-danger');
+        }
+        async function upload(){
+            var blob = new Blob(chunks,{type:'audio/webm'});
+            chunks=[];
+            var fd = new FormData();
+            fd.append('audio', blob, 'recording.webm');
+            fd.append('pid', window.nablaPid || 0);
+            fd.append('csrf_token_form', window.nablaCsrf);
+            try{
+                await fetch(window.nablaUploadUrl,{method:'POST',credentials:'same-origin',body:fd});
+            }catch(e){
+                console.error('Nabla upload failed',e);
+            }
+        }
+        btn.addEventListener('click', function(){
+            if(!recorder){
+                start().catch(e=>console.error('Recording failed',e));
+            }else if(recorder.state==='recording'){
+                stop();
+            }
+        });
+    });
+})();

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -1800,6 +1800,11 @@ if (
                                         value='<?php echo xla('Save and Print') ?>'>
                                         <?php echo xlt('Save and Print'); ?>
                                     </button>
+                                    <?php if (!empty($GLOBALS['gbl_nabla_ambient_listening'])) { ?>
+                                    <button type='button' class="btn btn-secondary" id="nabla-record-btn">
+                                        <?php echo xlt('Start Nabla Recording'); ?>
+                                    </button>
+                                    <?php } ?>
                                     <?php
                                     if (function_exists($formname . '_additional_buttons')) {
                                         // Allow the plug-in to insert more action buttons here.
@@ -1912,6 +1917,14 @@ if (
                     parent.postMessage({formid:<?php echo attr($formid) ?>}, window.location.origin);
                     <?php } ?>
                 </script>
+                <?php if (!empty($GLOBALS['gbl_nabla_ambient_listening'])) { ?>
+                <script>
+                    window.nablaUploadUrl = '<?php echo $GLOBALS['webroot']; ?>/interface/nabla_upload.php';
+                    window.nablaCsrf = '<?php echo CsrfUtils::collectCsrfToken(); ?>';
+                    window.nablaPid = <?php echo json_encode($pid); ?>;
+                </script>
+                <script src='<?php echo $GLOBALS['webroot']; ?>/interface/forms/LBF/nabla.js'></script>
+                <?php } ?>
 
             </div>
         </div>

--- a/interface/nabla_upload.php
+++ b/interface/nabla_upload.php
@@ -1,0 +1,47 @@
+<?php
+// Nabla ambient recording upload handler
+
+require_once(__DIR__ . '/globals.php');
+require_once($GLOBALS['fileroot'] . '/library/documents.php');
+require_once($GLOBALS['srcdir'] . '/api.inc.php');
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+
+header('Content-Type: application/json');
+
+if (!CsrfUtils::verifyCsrfToken($_POST['csrf_token_form'] ?? '')) {
+    http_response_code(400);
+    echo json_encode(['error' => 'CSRF validation failed']);
+    exit;
+}
+
+if (empty($_FILES['audio'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No audio provided']);
+    exit;
+}
+
+$pid = (int)($_POST['pid'] ?? 0);
+$category = document_category_to_id('Nabla Recordings');
+if (!$category) {
+    $category = sqlInsert("INSERT INTO categories (name) VALUES (?)", ['Nabla Recordings']);
+}
+
+$result = addNewDocument(
+    $_FILES['audio']['name'],
+    $_FILES['audio']['type'],
+    $_FILES['audio']['tmp_name'],
+    $_FILES['audio']['error'],
+    $_FILES['audio']['size'],
+    '',
+    $pid,
+    $category
+);
+
+if ($result === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Upload failed']);
+    exit;
+}
+
+echo json_encode(['success' => true, 'docId' => $result['doc_id']]);

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -989,6 +989,13 @@ $GLOBALS_METADATA = array(
             xl('This is helpful if visits usually do not have charges.')
         ),
 
+        'gbl_nabla_ambient_listening' => array(
+            xl('Enable Nabla Ambient Listening'),
+            'bool',
+            '0',
+            xl('Adds a start/stop recording button to layout based forms.')
+        ),
+
         'gbl_mask_patient_id' => array(
             xl('Mask for Patient IDs'),
             'text',                           // data type


### PR DESCRIPTION
## Summary
- add global to enable Nabla ambient recording
- support start/stop recording button on layout-based forms
- upload recordings via new Nabla endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*
- `vendor/bin/phpunit --version` *(failed: command not found)*
- `php -l interface/nabla_upload.php`
- `php -l interface/forms/LBF/new.php`

------
https://chatgpt.com/codex/tasks/task_e_6878e02895a083288ceba2b9f8c7d22e